### PR TITLE
Update cosmic-text

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/iced-rs/cryoglyph"
 license = "MIT OR Apache-2.0 OR Zlib"
 
 [dependencies]
-wgpu = { version = "27", default-features = false, features = ["wgsl"] }
+wgpu = { version = "28", default-features = false, features = ["wgsl"] }
 etagere = "0.2"
 cosmic-text = "0.16"
 lru = { version = "0.16", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 [dependencies]
 wgpu = { version = "28", default-features = false, features = ["wgsl"] }
 etagere = "0.2"
-cosmic-text = "0.16"
+cosmic-text = "0.18"
 lru = { version = "0.16", default-features = false }
 rustc-hash = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 [dependencies]
 wgpu = { version = "28", default-features = false, features = ["wgsl"] }
 etagere = "0.2"
-cosmic-text = "0.18"
+cosmic-text = "0.19"
 lru = { version = "0.16", default-features = false }
 rustc-hash = "2"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0 OR Zlib"
 [dependencies]
 wgpu = { version = "28", default-features = false, features = ["wgsl"] }
 etagere = "0.2"
-cosmic-text = "0.19"
+cosmic-text = { git = "https://github.com/pop-os/cosmic-text.git", rev = "4fe1195e6451d6aaa3dc383895d6fd366ea9fc7b" }
 lru = { version = "0.16", default-features = false }
 rustc-hash = "2"
 

--- a/benches/prepare.rs
+++ b/benches/prepare.rs
@@ -73,8 +73,8 @@ fn run_bench(ctx: &mut Criterion) {
             .copied()
             .map(|s| {
                 let mut text_buffer = Buffer::new(&mut font_system, Metrics::relative(1.0, 10.0));
-                text_buffer.set_size(&mut font_system, Some(20.0), None);
-                text_buffer.set_text(&mut font_system, s, &attrs, shaping, None);
+                text_buffer.set_size(Some(20.0), None);
+                text_buffer.set_text(s, &attrs, shaping, None);
                 text_buffer.shape_until_scroll(&mut font_system, false);
                 text_buffer
             })
@@ -85,7 +85,7 @@ fn run_bench(ctx: &mut Criterion) {
                 let text_areas: Vec<TextArea> = buffers
                     .iter()
                     .map(|b| TextArea {
-                        buffer: b,
+                        text: b.layout_runs(),
                         left: 0.0,
                         top: 0.0,
                         scale: 1.0,

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -213,6 +213,7 @@ impl winit::application::ApplicationHandler for Application {
                         depth_stencil_attachment: None,
                         timestamp_writes: None,
                         occlusion_query_set: None,
+                        multiview_mask: None,
                     });
 
                     text_renderer.render(&atlas, &viewport, &mut pass).unwrap();

--- a/examples/hello-world.rs
+++ b/examples/hello-world.rs
@@ -82,12 +82,8 @@ impl WindowState {
         let physical_width = (physical_size.width as f64 * scale_factor) as f32;
         let physical_height = (physical_size.height as f64 * scale_factor) as f32;
 
-        text_buffer.set_size(
-            &mut font_system,
-            Some(physical_width),
-            Some(physical_height),
-        );
-        text_buffer.set_text(&mut font_system, "Hello world! 👋\nThis is rendered with 🦅 glyphon 🦁\nThe text below should be partially clipped.\na b c d e f g h i j k l m n o p q r s t u v w x y z", &Attrs::new().family(Family::SansSerif), Shaping::Advanced, None);
+        text_buffer.set_size(Some(physical_width), Some(physical_height));
+        text_buffer.set_text("Hello world! 👋\nThis is rendered with 🦅 glyphon 🦁\nThe text below should be partially clipped.\na b c d e f g h i j k l m n o p q r s t u v w x y z", &Attrs::new().family(Family::SansSerif), Shaping::Advanced, None);
         text_buffer.shape_until_scroll(&mut font_system, false);
 
         Self {
@@ -179,7 +175,7 @@ impl winit::application::ApplicationHandler for Application {
                         atlas,
                         viewport,
                         [TextArea {
-                            buffer: text_buffer,
+                            text: text_buffer.layout_runs(),
                             left: 10.0,
                             top: 10.0,
                             scale: 1.0,

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -42,7 +42,7 @@ impl Cache {
             label: Some("glyphon sampler"),
             min_filter: FilterMode::Nearest,
             mag_filter: FilterMode::Nearest,
-            mipmap_filter: FilterMode::Nearest,
+            mipmap_filter: wgpu::MipmapFilterMode::Nearest,
             lod_min_clamp: 0f32,
             lod_max_clamp: 0f32,
             ..Default::default()
@@ -139,7 +139,7 @@ impl Cache {
         let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
             label: None,
             bind_group_layouts: &[&atlas_layout, &uniforms_layout],
-            push_constant_ranges: &[],
+            immediate_size: 0,
         });
 
         Self(Arc::new(Inner {
@@ -237,7 +237,7 @@ impl Cache {
                     },
                     depth_stencil: depth_stencil.clone(),
                     multisample,
-                    multiview: None,
+                    multiview_mask: None,
                     cache: None,
                 });
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,9 @@ impl Default for TextBounds {
 }
 
 /// A text area containing text to be rendered along with its overflow behavior.
-#[derive(Clone)]
 pub struct TextArea<'a> {
     /// The buffer containing the text to be rendered.
-    pub buffer: &'a Buffer,
+    pub text: LayoutRunIter<'a>,
     /// The left edge of the buffer.
     pub left: f32,
     /// The top edge of the buffer.

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -39,7 +39,7 @@ impl TextRenderer {
         let pipeline = atlas.get_or_create_pipeline(device, multisample, depth_stencil);
 
         Self {
-            staging_belt: StagingBelt::new(vertex_buffer_size),
+            staging_belt: StagingBelt::new(device.clone(), vertex_buffer_size),
             vertex_buffer,
             vertex_buffer_size,
             pipeline,
@@ -295,7 +295,6 @@ impl TextRenderer {
                     &self.vertex_buffer,
                     0,
                     NonZeroU64::new(vertices_raw.len() as u64).expect("Non-empty vertices"),
-                    device,
                 )
                 .copy_from_slice(vertices_raw);
         } else {
@@ -312,7 +311,7 @@ impl TextRenderer {
             self.vertex_buffer_size = buffer_size;
 
             self.staging_belt.finish();
-            self.staging_belt = StagingBelt::new(buffer_size);
+            self.staging_belt = StagingBelt::new(device.clone(), buffer_size);
         }
 
         self.staging_belt.finish();

--- a/src/text_render.rs
+++ b/src/text_render.rs
@@ -81,8 +81,7 @@ impl TextRenderer {
             };
 
             let layout_runs = text_area
-                .buffer
-                .layout_runs()
+                .text
                 .skip_while(|run| !is_run_visible(run))
                 .take_while(is_run_visible);
 


### PR DESCRIPTION
We're using wgpu 28 for libcosmic, the upstream cryoglyph is on wgpu 29. So we have to revive this fork. The pop fork of Iced is on commit e429a02 ([here](https://github.com/pop-os/iced/blob/9f410558611b6e7e1027a7b227a7fab0b9019b93/Cargo.toml#L242)). This PR only adds one commit to use the latest cosmic-text, pinned to a specific commit to avoid any breaking change issues in the future cosmic-text versions.